### PR TITLE
Show information on LiveView page instead of Phoenix error

### DIFF
--- a/lib/helpdesk_web/live/home_live.html.leex
+++ b/lib/helpdesk_web/live/home_live.html.leex
@@ -1,51 +1,58 @@
-<section class="phx-hero">
-  <h1><%= gettext "Welcome to %{name}, %{first_name}!", name: "Helpdesk", first_name: @me.first_name %></h1>
-  <h2>You have <%= @me.open_ticket_count %> open tickets</h2>
-</section>
-<table class="card-body table">
-  <thead>
-    <tr>
-      <th>Id</th>
-      <th>Status</th>
-      <th>Subject</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= for ticket <- @tickets.results do %>
-    <tr>
-      <td><%= ticket.id %></td>
-      <td><%= ticket.status %></td>
-      <td><%= ticket.subject %></td>
-      <td class="w-1/12 whitespace-no-wrap">
-        <span class="text-sm mr-1"><%= link "Show", to: "/" %></span>
-        <span class="text-sm mr-1"><%= link "Edit", to: "/" %></span>
-        <span class="text-sm"><%= link "Delete", to: "/", method: :delete, data: [confirm: "Are you sure?"] %></span>
-      </td>
+<%= if @me do %>
+  <section class="phx-hero">
+    <h1><%= gettext "Welcome to %{name}, %{first_name}!", name: "Helpdesk", first_name: @me.first_name %></h1>
+    <h2>You have <%= @me.open_ticket_count %> open tickets</h2>
+  </section>
+  <table class="card-body table">
+    <thead>
+      <tr>
+        <th>Id</th>
+        <th>Status</th>
+        <th>Subject</th>
+        <th></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <%= for ticket <- @tickets.results do %>
+      <tr>
+        <td><%= ticket.id %></td>
+        <td><%= ticket.status %></td>
+        <td><%= ticket.subject %></td>
+        <td class="w-1/12 whitespace-no-wrap">
+          <span class="text-sm mr-1"><%= link "Show", to: "/" %></span>
+          <span class="text-sm mr-1"><%= link "Edit", to: "/" %></span>
+          <span class="text-sm"><%= link "Delete", to: "/", method: :delete, data: [confirm: "Are you sure?"] %></span>
+        </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 
 
-<nav class="border-t border-gray-200">
-  <ul class="flex my-2">
-  <%= if can_link_to_page?(@tickets, "prev") do %>
-    <li class="">
-      <a class="px-2 py-2" href="#" phx-click="nav" phx-value-page="<%= :prev %>">Previous</a>
-    </li>
-  <% end %>
-  <%= unless last_page(@tickets) == :unknown do %>
-    <%= for idx <-  1..last_page(@tickets) do %>
+  <nav class="border-t border-gray-200">
+    <ul class="flex my-2">
+    <%= if can_link_to_page?(@tickets, "prev") do %>
       <li class="">
-        <a class="px-2 py-2 <%= if on_page?(@tickets, idx), do: "pointer-events-none text-gray-600" %>" href="#" phx-click="nav" phx-value-page="<%= idx %>"><%= idx %></a>
+        <a class="px-2 py-2" href="#" phx-click="nav" phx-value-page="<%= :prev %>">Previous</a>
       </li>
     <% end %>
-  <% end %>
-  <%= if can_link_to_page?(@tickets, "next") do %>
-    <li class="">
-      <a class="px-2 py-2 <%= unless can_link_to_page?(@tickets, "next"), do: "pointer-events-none text-gray-600" %>" href="#" phx-click="nav" phx-value-page="<%= :next %>">Next</a>
-    </li>
-  <% end %>
-  </ul>
-</nav>
+    <%= unless last_page(@tickets) == :unknown do %>
+      <%= for idx <-  1..last_page(@tickets) do %>
+        <li class="">
+          <a class="px-2 py-2 <%= if on_page?(@tickets, idx), do: "pointer-events-none text-gray-600" %>" href="#" phx-click="nav" phx-value-page="<%= idx %>"><%= idx %></a>
+        </li>
+      <% end %>
+    <% end %>
+    <%= if can_link_to_page?(@tickets, "next") do %>
+      <li class="">
+        <a class="px-2 py-2 <%= unless can_link_to_page?(@tickets, "next"), do: "pointer-events-none text-gray-600" %>" href="#" phx-click="nav" phx-value-page="<%= :next %>">Next</a>
+      </li>
+    <% end %>
+    </ul>
+  </nav>
+<% else %>
+  <section class="phx-hero">
+    <h1><%= gettext "Welcome to %{name}, %{first_name}!", name: "Helpdesk", first_name: "Anonymous user" %></h1>
+    <h2>Please pass user ID into <code>User-Id</code> header to log in</h2>
+  </section>
+<% end %>

--- a/test/helpdesk_web/live/home_live_test.exs
+++ b/test/helpdesk_web/live/home_live_test.exs
@@ -5,7 +5,7 @@ defmodule HelpdeskWeb.HomeLiveTest do
 
   test "disconnected and connected render", %{conn: conn} do
     {:ok, home_live, disconnected_html} = live(conn, "/")
-    assert disconnected_html =~ "Welcome to Phoenix!"
-    assert render(home_live) =~ "Welcome to Phoenix!"
+    assert disconnected_html =~ "Welcome to Helpdesk"
+    assert render(home_live) =~ "Welcome to Helpdesk"
   end
 end


### PR DESCRIPTION
If I open the page mentioned in Readme.md, I see an error:
![Screenshot_20220510_221204](https://user-images.githubusercontent.com/4661021/167704981-e417f778-4c33-48c4-b370-b10dfd9f4ced.png)

This is because I've opened LiveView page without User-Id header, so there is no `actor` in the current context.

IMHO. it's better to show some instruction instead:
![Screenshot_20220510_221227](https://user-images.githubusercontent.com/4661021/167705011-cb6ebac4-9eb1-41d8-b9db-8089f7e89cde.png)

